### PR TITLE
Don't crash when users haven't installed the dracula theme

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,8 +11,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 from n2o_esdu import thermophys
 
-
-plt.style.use('dracula')
+if 'dracula' in plt.style.available:
+    plt.style.use('dracula')
 
 ZERO_C = 273.15
 


### PR DESCRIPTION
My heart breaks with this commit... while I absolutely love the idea of this simulation unexpectedly crashing when dracula isn't installed, after spotting this bug I regrettably felt a sense of duty to open this PR.